### PR TITLE
Fixed categories issue

### DIFF
--- a/infty/api/v1/core/serializers.py
+++ b/infty/api/v1/core/serializers.py
@@ -26,6 +26,12 @@ class TopicSerializer(serializers.HyperlinkedModelSerializer):
         queryset=Topic.objects.all(),
         required=False)
 
+    categories = serializers.HyperlinkedRelatedField(
+        many=True,
+        view_name='api:v1:meta:type-detail',
+        queryset=Topic.objects.all(),
+        required=False)
+
     class Meta:
         model = Topic
         extra_kwargs = {'url': {'view_name': 'api:v1:core:topic-detail'}}

--- a/infty/api/v1/core/views.py
+++ b/infty/api/v1/core/views.py
@@ -1,4 +1,3 @@
-from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework import viewsets, filters
 
@@ -82,7 +81,6 @@ class CommentViewSet(CustomViewSet):
         return qs
 
 
-@permission_classes((IsAuthenticatedOrReadOnly,))
 class UserBalanceViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend,
                        filters.SearchFilter,)
@@ -91,9 +89,10 @@ class UserBalanceViewSet(viewsets.ReadOnlyModelViewSet):
 
     serializer_class = UserBalanceSerializer
     queryset = User.objects.all()
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
 
-@permission_classes((IsAuthenticatedOrReadOnly,))
 class LanguageNameViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = LanguageNameSerializer
     queryset = LanguageName.objects.all()
+    permission_classes = (IsAuthenticatedOrReadOnly,)


### PR DESCRIPTION
When categories is not empty we had an error: Could not resolve URL...
The reason was that for namespacing we have to define the view_name:
http://www.django-rest-framework.org/api-guide/routers/#usage